### PR TITLE
Use NguyenWidrowRandomizer in BasicNetwork.reset(seed)

### DIFF
--- a/src/main/java/org/encog/neural/networks/BasicNetwork.java
+++ b/src/main/java/org/encog/neural/networks/BasicNetwork.java
@@ -27,6 +27,7 @@ import org.encog.Encog;
 import org.encog.engine.network.activation.ActivationFunction;
 import org.encog.mathutil.randomize.ConsistentRandomizer;
 import org.encog.mathutil.randomize.NguyenWidrowRandomizer;
+import org.encog.mathutil.randomize.Randomizer;
 import org.encog.mathutil.randomize.RangeRandomizer;
 import org.encog.ml.BasicML;
 import org.encog.ml.MLClassification;
@@ -610,22 +611,39 @@ public class BasicNetwork extends BasicML implements ContainsFlat, MLContext,
 	 */
 	@Override
 	public void reset() {
-
-		if (getLayerCount() < 3) {
-			(new RangeRandomizer(-1, 1)).randomize(this);
-		} else {
-			(new NguyenWidrowRandomizer()).randomize(this);
-		}
+		getRandomizer().randomize(this);
 	}
 
 	/**
-	 * Randomize between -1 and 1, use the specified seed.
+	 * Reset the weight matrix and the bias values. This will use a
+	 * Nguyen-Widrow randomizer with a range between -1 and 1. If the network
+	 * does not have an input, output or hidden layers, then Nguyen-Widrow
+	 * cannot be used and a simple range randomize between -1 and 1 will be
+	 * used. Use the specified seed.
 	 * 
 	 */
 	@Override
 	public void reset(final int seed) {
-		ConsistentRandomizer randomizer = new ConsistentRandomizer(-1,1,seed);
+		Randomizer randomizer = getRandomizer();
+		randomizer.setSeed(seed);
 		randomizer.randomize(this);
+	}
+	
+	/**
+	 * Determindes the randomizer used for resets. This will normally return a
+	 * Nguyen-Widrow randomizer with a range between -1 and 1. If the network
+	 * does not have an input, output or hidden layers, then Nguyen-Widrow
+	 * cannot be used and a simple range randomize between -1 and 1 will be
+	 * used.
+	 * 
+	 * @return the randomizer
+	 */
+	private Randomizer getRandomizer() {
+		if (getLayerCount() < 3) {
+			return new RangeRandomizer(-1,1);
+		} else {
+			return new NguyenWidrowRandomizer();
+		}
 	}
 
 	/**


### PR DESCRIPTION
Thanks to Robert Coop's change 61ebdaf0c1c30426d314a1b5a5a4875edadae6b we can now use the NguyenWidrowRandomizer with a given seed. The NguyenWidrowRandomizer had been removed from BasicNetwork.reset(seed) in 884a95eaaf3f4cdfa6a39f0c8327d6edd5fb8f68 because at that time it didn't use seeds.

RangeRandomizer and NguyenWidrowRandomizer now both work with the setSeed method, so the choice of the Randomizer doesn't depend any longer on whether or not a seed is given and can be unified in a private function getRandomizer().
