### PR TITLE
Fix ternary operator in NEAT crossover

### DIFF
--- a/src/main/java/org/encog/neural/neat/training/opp/NEATCrossover.java
+++ b/src/main/java/org/encog/neural/neat/training/opp/NEATCrossover.java
@@ -220,7 +220,7 @@ public class NEATCrossover implements EvolutionaryOperator {
 		final NEATGenome dad = (NEATGenome) parents[parentIndex + 1];
 
 		final NEATGenome best = favorParent(mom, dad);
-		final NEATGenome notBest = (best == mom) ? mom : dad;
+		final NEATGenome notBest = (best != mom) ? mom : dad;
 
 		final List<NEATLinkGene> selectedLinks = new ArrayList<NEATLinkGene>();
 		final List<NEATNeuronGene> selectedNeurons = new ArrayList<NEATNeuronGene>();


### PR DESCRIPTION
- Previously: "not best" genome always equal to "best" genome
