### PR TITLE
Improve NEAT genome initialization

### DIFF
--- a/src/main/java/org/encog/neural/neat/training/NEATGenome.java
+++ b/src/main/java/org/encog/neural/neat/training/NEATGenome.java
@@ -190,11 +190,10 @@ public class NEATGenome extends BasicGenome implements Cloneable, Serializable {
 		}
 
 		// and now links
+		boolean haveInputOutputLink = false;
 		for (int i = 0; i < inputCount + 1; i++) {
 			for (int j = 0; j < outputCount; j++) {
-				// make sure we have at least one connection
-				if (this.linksList.size() < 1
-						|| rnd.nextDouble() < connectionDensity) {
+				if (rnd.nextDouble() < connectionDensity) {
 					long fromID = this.neuronsList.get(i).getId();
 					long toID = this.neuronsList.get(inputCount + j + 1)
 							.getId();
@@ -203,8 +202,27 @@ public class NEATGenome extends BasicGenome implements Cloneable, Serializable {
 					NEATLinkGene gene = new NEATLinkGene(fromID, toID, true,
 							innovationID++, w);
 					this.linksList.add(gene);
+
+					if (i != 0) { // if not bias node
+						haveInputOutputLink = true;
+					}
 				}
 			}
+		}
+
+		// make sure we have at least one connection between inputs and outputs
+		if (!haveInputOutputLink) {
+			// choose a random input/output pair
+			int inputIndex = (int) (rnd.nextDouble() * inputCount) + 1;
+			int outputIndex = (int) (rnd.nextDouble() * outputCount)
+					+ inputCount + 1;
+			long fromID = this.neuronsList.get(inputIndex).getId();
+			long toID = this.neuronsList.get(outputIndex).getId();
+			double w = RangeRandomizer.randomize(rnd, -pop.getWeightRange(),
+					pop.getWeightRange());
+			NEATLinkGene gene = new NEATLinkGene(fromID, toID, true,
+					innovationID, w);
+			this.linksList.add(gene);
 		}
 
 	}


### PR DESCRIPTION
- The NEAT genome initialization ensures that there is at least one
  link in a newly created random network. The problem was that this
  was achieved by always linking the bias node (node at index 0) to
  the first output node (node at index `inputCount + 1`).
- This change ensures that there is some link between _input_ and
  output nodes by creating a link from a random input node to a random
  output node if one was not created during the regular link
  initialization procedure.
