### PR TITLE
encog-java-core #194: NormalizationHelper is not serializable

### DIFF
--- a/src/main/java/org/encog/ml/data/versatile/columns/ColumnDefinition.java
+++ b/src/main/java/org/encog/ml/data/versatile/columns/ColumnDefinition.java
@@ -265,7 +265,7 @@ public class ColumnDefinition implements Serializable {
 	}
 
 	@Override
-	public boolean equals(Object obj) {
+	public boolean equals(Object obj) { 
 		boolean result;
 		if ( obj instanceof ColumnDefinition ) {
 			ColumnDefinition that = (ColumnDefinition) obj;

--- a/src/main/java/org/encog/ml/data/versatile/normalizers/IndexedNormalizer.java
+++ b/src/main/java/org/encog/ml/data/versatile/normalizers/IndexedNormalizer.java
@@ -37,7 +37,7 @@ public class IndexedNormalizer implements Normalizer {
 
  	@Override
  	public boolean equals(Object obj) {
- 		return ( obj instanceof IndexedNormalizer );
+ 		return ( obj instanceof IndexedNormalizer ); 
  	}
  	
 	/**

--- a/src/main/java/org/encog/ml/data/versatile/normalizers/Normalizer.java
+++ b/src/main/java/org/encog/ml/data/versatile/normalizers/Normalizer.java
@@ -32,7 +32,7 @@ import org.encog.ml.data.versatile.columns.ColumnDefinition;
  * The normalizer interface defines how to normalize a column.  The source of the
  * normalization can be either string or double.
  */
-public interface Normalizer extends Serializable {
+public interface Normalizer extends Serializable { 
 
 	/**
 	 * Determine the normalized size of the specified column.

--- a/src/main/java/org/encog/ml/data/versatile/normalizers/OneOfNNormalizer.java
+++ b/src/main/java/org/encog/ml/data/versatile/normalizers/OneOfNNormalizer.java
@@ -55,7 +55,7 @@ public class OneOfNNormalizer implements Normalizer {
 	}
 
  	@Override
- 	public boolean equals(Object obj) {
+ 	public boolean equals(Object obj) { 
  		boolean result;
  		
  		if ( obj instanceof OneOfNNormalizer ) {

--- a/src/main/java/org/encog/ml/data/versatile/normalizers/PassThroughNormalizer.java
+++ b/src/main/java/org/encog/ml/data/versatile/normalizers/PassThroughNormalizer.java
@@ -34,7 +34,7 @@ public class PassThroughNormalizer implements Normalizer {
 	private static final long serialVersionUID = 1L;
 
  	@Override
- 	public boolean equals(Object obj) {
+ 	public boolean equals(Object obj) { 
  		return ( obj instanceof PassThroughNormalizer );
  	}
  	

--- a/src/main/java/org/encog/ml/data/versatile/normalizers/RangeNormalizer.java
+++ b/src/main/java/org/encog/ml/data/versatile/normalizers/RangeNormalizer.java
@@ -56,7 +56,7 @@ public class RangeNormalizer implements Normalizer {
 	
 
  	@Override
- 	public boolean equals(Object obj) {
+ 	public boolean equals(Object obj) { 
  		boolean result;
  		
  		if ( obj instanceof RangeNormalizer ) {

--- a/src/main/java/org/encog/ml/data/versatile/normalizers/RangeOrdinal.java
+++ b/src/main/java/org/encog/ml/data/versatile/normalizers/RangeOrdinal.java
@@ -51,7 +51,7 @@ public class RangeOrdinal implements Normalizer {
 	}
 
  	@Override
- 	public boolean equals(Object obj) {
+ 	public boolean equals(Object obj) { 
  		boolean result;
  		
  		if ( obj instanceof RangeOrdinal ) {

--- a/src/main/java/org/encog/ml/data/versatile/normalizers/strategies/BasicNormalizationStrategy.java
+++ b/src/main/java/org/encog/ml/data/versatile/normalizers/strategies/BasicNormalizationStrategy.java
@@ -78,7 +78,7 @@ public class BasicNormalizationStrategy implements NormalizationStrategy {
 	}
 
 	@Override
-	public boolean equals(Object obj) {
+	public boolean equals(Object obj) { 
 		boolean result;
 		
 		if ( obj instanceof BasicNormalizationStrategy ) {

--- a/src/main/java/org/encog/ml/data/versatile/normalizers/strategies/NormalizationStrategy.java
+++ b/src/main/java/org/encog/ml/data/versatile/normalizers/strategies/NormalizationStrategy.java
@@ -31,7 +31,7 @@ import org.encog.ml.data.versatile.columns.ColumnDefinition;
 /**
  * Defines the interface to a normalization strategy.
  */
-public interface NormalizationStrategy extends Serializable {
+public interface NormalizationStrategy extends Serializable { 
 
 	/**
 	 * Calculate how many elements a column will normalize into.

--- a/src/test/java/org/encog/ml/data/versatile/TestNormalizationHelper.java
+++ b/src/test/java/org/encog/ml/data/versatile/TestNormalizationHelper.java
@@ -12,7 +12,7 @@ import org.encog.util.SerializeRoundTrip;
 import org.junit.Assert;
 import org.junit.Test;
 
-public class TestNormalizationHelper {
+public class TestNormalizationHelper { 
 	@Test
 	public void testDefaultSerial() throws ClassNotFoundException, IOException {
 		NormalizationHelper out = new NormalizationHelper();


### PR DESCRIPTION
This change addresses the issue at https://github.com/encog/encog-java-core/issues/194 : NormalizationHelper is not serializable.

This change includes making the following Serializable:
- NormalizationStrategy and its subclass BasicNormalizationStrategy
- Normalizer and its subclasses

This change adds a new unit test to verify serializability of NormalizationHelper: org.encog.ml.data.versatile.TestNormalizationHelper. 

To support the unit test, equals() methods were added to the following:
- ColumnDefinition
- Normalizer subclasses
- BasicNormalizationStrategy

Also, this pull request includes a trivial fix for encog-java-core #192: ColumnDefinition: default index should be -1. More detail:  https://github.com/encog/encog-java-core/issues/192 

All unit tests are green after these changes. A test build succeeded.
