### PR TITLE
Make BasicEA not serializable

### DIFF
--- a/src/main/java/org/encog/ml/ea/train/basic/BasicEA.java
+++ b/src/main/java/org/encog/ml/ea/train/basic/BasicEA.java
@@ -23,7 +23,6 @@
  */
 package org.encog.ml.ea.train.basic;
 
-import java.io.Serializable;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.concurrent.Callable;
@@ -68,12 +67,7 @@ import org.encog.util.logging.EncogLogging;
  * The EA works from a score function.
  */
 public class BasicEA implements EvolutionaryAlgorithm, MultiThreadable,
-		EncogShutdownTask, Serializable {
-
-	/**
-	 * The serial id.
-	 */
-	private static final long serialVersionUID = 1L;
+		EncogShutdownTask {
 
 	/**
 	 * Calculate the score adjustment, based on adjusters.

--- a/src/main/java/org/encog/ml/ea/train/basic/TrainEA.java
+++ b/src/main/java/org/encog/ml/ea/train/basic/TrainEA.java
@@ -41,11 +41,6 @@ import org.encog.neural.networks.training.propagation.TrainingContinuation;
  * Provides a MLTrain compatible class that can be used to train genomes.
  */
 public class TrainEA extends BasicEA implements MLTrain {
-
-	/**
-	 * The serial ID.
-	 */
-	private static final long serialVersionUID = 1L;
 	
 	/**
 	 * The training strategies to use.


### PR DESCRIPTION
* The majority of the fields in BasicEA are not serializable so
  labelling the class as Serializable is misleading.