### PR TITLE
Fix global best position update in PSO

### DIFF
--- a/src/main/java/org/encog/neural/networks/training/pso/NeuralPSO.java
+++ b/src/main/java/org/encog/neural/networks/training/pso/NeuralPSO.java
@@ -304,10 +304,12 @@ public class NeuralPSO extends BasicTraining {
      */
     protected void updateGlobalBestPosition() {
         boolean bestUpdated = false;
+        double currentBestError = getError();
         for (int i = 0; i < m_populationSize; i++) {
-            if ((m_bestVectorIndex == -1) || isScoreBetter(m_bestErrors[i], m_bestErrors[m_bestVectorIndex])) {
+            if ((m_bestVectorIndex == -1) || isScoreBetter(m_bestErrors[i], currentBestError)) {
                 m_bestVectorIndex = i;
                 bestUpdated = true;
+                currentBestError = m_bestErrors[i];
             }
         }
         if (bestUpdated) {


### PR DESCRIPTION
The udateGlobalBestPosition() method in NeuralPSO fails if the current best particle finds a better position, because the old method was comparing the new error with the new error in the array, which are equal. Now, it is comparing against the old error saved in the BasicTraining class.

If you're going to merge this, I would be interested to know about in which version this fix will be published, as I'm using this code in my current project build with gradle.