### PR TITLE
fixed copy-paste error in SubstrateFactory

### DIFF
--- a/src/main/java/org/encog/neural/hyperneat/substrate/SubstrateFactory.java
+++ b/src/main/java/org/encog/neural/hyperneat/substrate/SubstrateFactory.java
@@ -55,9 +55,9 @@ public class SubstrateFactory {
 		Substrate result = new Substrate(3);
 
 		double inputTick = 2.0 / inputEdgeSize;
-		double outputTick = 2.0 / inputEdgeSize;
+		double outputTick = 2.0 / outputEdgeSize;
 		double inputOrig = -1.0 + (inputTick / 2.0);
-		double outputOrig = -1.0 + (inputTick / 2.0);
+		double outputOrig = -1.0 + (outputTick / 2.0);
 
 		// create the input layer
 


### PR DESCRIPTION
This fixes what appears to be a copy-paste error in `SubstrateFactory.factorSandwichSubstrate` that causes the nodes in the output substrate layer to be positioned as though the output layer is the same size as the input layer - which may not be not the case.