### PR TITLE
Ml method genetic algorithm finish training fix

### DIFF
--- a/src/main/java/org/encog/ml/genetic/MLMethodGeneticAlgorithm.java
+++ b/src/main/java/org/encog/ml/genetic/MLMethodGeneticAlgorithm.java
@@ -207,8 +207,17 @@ public class MLMethodGeneticAlgorithm extends BasicTraining implements
 	public void resume(final TrainingContinuation state) {
 
 	}
+	
+	/* (non-Javadoc)l
+   * @see org.encog.ml.train.BasicTraining#finishTraining()
+   */
+  @Override
+  public void finishTraining() {
+    super.finishTraining();
+    this.genetic.finishTraining();
+  }
 
-	/**
+  /**
 	 * Set the genetic helper class.
 	 * 
 	 * @param genetic

--- a/src/main/java/org/encog/ml/importance/AbstractFeatureImportance.java
+++ b/src/main/java/org/encog/ml/importance/AbstractFeatureImportance.java
@@ -21,7 +21,7 @@ public abstract class AbstractFeatureImportance implements FeatureImportance {
     /**
      * The features that were ranked.
      */
-    private final List<FeatureRank> features = new ArrayList<>();
+    private final List<FeatureRank> features = new ArrayList<FeatureRank>();
 
     /**
      * {@inheritDoc}
@@ -60,7 +60,7 @@ public abstract class AbstractFeatureImportance implements FeatureImportance {
      * @return The features sorted by importance.
      */
     public Collection<FeatureRank> getFeaturesSorted() {
-        Set<FeatureRank> result = new TreeSet<>();
+        Set<FeatureRank> result = new TreeSet<FeatureRank>();
         result.addAll(this.features);
         return result;
     }


### PR DESCRIPTION
This PR contains 2 fixes:

1)   	Removing use of diamond operator to ensure compatibility with Java 1.6 - as specified by the pom.xml

2)    Ensuring that the finishTraining() method of MLMethodGeneticAlgorithm also calls finishTraining() on it's internal helper class.   Not calling finishTraining() on the helper class can result in un-shutdown Task Executors and appears to cause a memory leak