### PR TITLE
modify the if statment which check if center[i] at the boundary of th…

### DIFF
--- a/src/main/java/org/encog/neural/rbf/RBFNetwork.java
+++ b/src/main/java/org/encog/neural/rbf/RBFNetwork.java
@@ -301,7 +301,7 @@ public class RBFNetwork extends BasicML implements MLError, MLRegression,
 			boolean contains = false;
 
 			for (int z = 0; z < centers[0].length; z++) {
-				if ((centers[i][z] == 1.0) || (centers[i][z] == 0.0)) {
+				if ((centers[i][z] == maxPosition) || (centers[i][z] == minPosition)) {
 					contains = true;
 				}
 			}


### PR DESCRIPTION
modify the if statment which check if center[i] at the boundary of the neuron mesh
the boundary of the neuron mesh is minPosition and maxPosition, two parameters of "setRBFCentersAndWidthsEqualSpacing" method, right?
They may have various values, though typically 0 and 1. For example in the constructor "public RBFNetwork(final int inputCount, final int hiddenCount, final int outputCount, final RBFEnum t)", setRBFCentersAndWidthsEqualSpacing method is called with patameters minPosition = -1 and maxPosition = 1
so, I think the boundary check should be like this:
if ((centers[i][z] == minPosition) || (centers[i][z] == maxPosition))
